### PR TITLE
MongoDB Path Fixes

### DIFF
--- a/Configure-Component.ps1
+++ b/Configure-Component.ps1
@@ -196,11 +196,11 @@ $Components = @{
         if (!$Silent) {Write-AP-Wrapper "+Configured Java [$($JavaD.substring(3)) $(if($x86){'32'}else{'64'})-bit] for AP-PShell Management Console!",$SubMsg}
         rv JavaD}
     MongoDB = {
-        $PyD = @((item C:\Mongo*,C:\AP-Langs\MongoDB*).FullName)[-1]
+        $PyD = @((item C:\Mongo*,C:\AP-Langs\MongoDB*,C:\Program*File*\Mongo*).FullName)[-1]
         if (!$PyD) {Throw "MongoDB Does not Exist on System!";exit}
-        A2Path "$PyD\bin"
-        if ($a = (Split-Path -leaf $PyD).substring(7)) {$a="[$a]"}
-        if (!$Silent) {Write-AP-Wrapper "+Configured MongoDB$a for AP-PShell Management Console!"}
+        pushd $PyD;$PyD = split-path @(ls -r mongod.exe)[0];popd
+        A2Path "$PyD"
+        if (!$Silent) {Write-AP-Wrapper "+Configured MongoDB[$((mongod -version)[0].split(" ")[-1])] for AP-PShell Management Console!"}
         rv PYD}
     PHP = {param([ValidateSet("5.4","5.6")]$Version="5.6")
         $PyD = Resolve-Path "C:\AP-Langs\PHP-$Version.*" -ea SilentlyContinue

--- a/Configure-Component.ps1
+++ b/Configure-Component.ps1
@@ -198,7 +198,8 @@ $Components = @{
     MongoDB = {
         $PyD = @((item C:\Mongo*,C:\AP-Langs\MongoDB*,C:\Program*File*\Mongo*).FullName)[-1]
         if (!$PyD) {Throw "MongoDB Does not Exist on System!";exit}
-        pushd $PyD;$PyD = split-path @(ls -r mongod.exe)[0];popd
+        pushd $PyD;$t = @(ls -r mongod.exe)[0];if (!$t) {$t="/"};$PyD = split-path $t -ea SilentlyContinue;popd
+        if (!$PyD) {throw "MongoDB has a folder, but no installation??";exit}
         A2Path "$PyD"
         if (!$Silent) {Write-AP-Wrapper "+Configured MongoDB[$((mongod -version)[0].split(" ")[-1])] for AP-PShell Management Console!"}
         rv PYD}


### PR DESCRIPTION
#### MongoDB Path fixes:
- [x] Path detection in `Program Files` or `x86 version` with Wildcard [42482ae5a45ee3eb29c25cc67f70bab3bb9249ce]
- [x] Complete Path recursion by binary file! [42482ae5a45ee3eb29c25cc67f70bab3bb9249ce]
- [x] Error detection in case no binary was found [d7c69bc647d3a9add4a6866da157f134bbf93cf1]
- [x] Version printed with Binary signature rather than directory scraping [42482ae5a45ee3eb29c25cc67f70bab3bb9249ce]
